### PR TITLE
More multi-stage support: `AS` and `--from=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,21 @@ file.healthCheck({
 
 file.user('root');
 // USER root
+```
 
-file.from({ image: 'node', registry: 'docker.io', tag: '10-alpine' })
-// FROM docker.io/node:10-alpine
+#### Multi-stage builds
+```javascript
+file.from({ image: 'node', registry: 'docker.io', tag: '10-alpine', stage: 'build' })
+// FROM docker.io/node:10-alpine AS build
+
+// ... run your build commands here ...
 
 file.stage()
 // Adds a new stage
 
 file.from({ image: 'node', registry: 'docker.io', tag: '10-alpine' })
 // Sets the `FROM` instruction in the new stage, etc ...
+
+file.copy({ from: 'build', src: ['./lib'], dest: './lib' })
+// COPY --from=build ["./lib", "./lib"]
 ```

--- a/lib/instruction.js
+++ b/lib/instruction.js
@@ -339,13 +339,17 @@ function env(env, onbuild) {
 }
 
 // used to generate add and copy since they are of the same form
-function copyInternal(command, src, dest, onbuild) {
+function copyInternal(command, src, dest, flags, onbuild) {
   var instruction = null
   src = boxAndFilter(src)
 
   if(src.length == 0) {
     throw new errors.EmptyArrayError(command, 'src')
   }
+
+  flags.forEach(flag => {
+    command += ` --${flag[0]}=${flag[1]}`
+  })
 
   if(dest && dest.length) {
     instruction = `${command} [${src.map(enQuote).join(', ')}, "${dest}"]`
@@ -365,7 +369,13 @@ function add(add, onbuild) {
   var instruction = null
   const src = add.src
   const dest = add.dest
-  instruction = copyInternal('ADD', src, dest, onbuild)
+
+  const flags = []
+  if (add.chown) {
+    flags.push(['chown', add.chown])
+  }
+
+  instruction = copyInternal('ADD', src, dest, flags, onbuild)
   return instruction
 }
 
@@ -378,7 +388,16 @@ function copy(copy, onbuild) {
   var instruction = null
   const src = copy.src
   const dest = copy.dest
-  instruction = copyInternal('COPY', src, dest, onbuild)
+
+  const flags = []
+  if (copy.chown) {
+    flags.push(['chown', copy.chown])
+  }
+  if (copy.from) {
+    flags.push(['from', copy.from])
+  }
+
+  instruction = copyInternal('COPY', src, dest, flags, onbuild)
   return instruction
 }
 

--- a/lib/instruction.js
+++ b/lib/instruction.js
@@ -31,6 +31,7 @@ function from(from) {
   const tag = from.tag
   const digest = from.digest
   const registry = from.registry
+  const stage = from.stage
 
   if(!image && typeof from === 'string') {
     image = from
@@ -49,6 +50,10 @@ function from(from) {
     }
   } else {
     throw new errors.MissingPropertyError('from', 'image', image)
+  }
+
+  if (stage) {
+    instruction += ` AS ${stage}`
   }
 
   return instruction

--- a/lib/model.js
+++ b/lib/model.js
@@ -33,11 +33,14 @@ const DockerfileModel = {
   env : {},
   add : {
     src: [],
-    dest: ''
+    dest: '',
+    chown: ''
   },
   copy: {
     src: [],
-    dest: ''
+    dest: '',
+    chown: '',
+    from: ''
   },
   user: '',
   workdir: '',

--- a/lib/model.js
+++ b/lib/model.js
@@ -3,7 +3,8 @@ const DockerfileModel = {
     image : null,
     tag : null,
     digest : null,
-    registry : null
+    registry : null,
+    stage : null
   },
   maintainer : {
     name : null

--- a/test/instruction/test_add.js
+++ b/test/instruction/test_add.js
@@ -27,6 +27,22 @@ describe('testing instruction add', ()=> {
     })
   })
 
+  describe('with chown flag (shorthand)', ()=> {
+    const expect = 'ADD --chown=42 ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.add({ src: ['src'], dest: 'dest', chown: 42 })
+      assert.equal(result, expect)
+    })
+  })
+
+  describe('with chown flag (longhand)', ()=> {
+    const expect = 'ADD --chown=user:group ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.add({ src: ['src'], dest: 'dest', chown: 'user:group' })
+      assert.equal(result, expect)
+    })
+  })
+
   describe('for invalid input', ()=> {
     it('should throw on either null', ()=> {
       assert.throws(() => { ins.add({src: null, dest:null}) })

--- a/test/instruction/test_copy.js
+++ b/test/instruction/test_copy.js
@@ -27,6 +27,38 @@ describe('testing instruction copy', ()=> {
     })
   })
 
+  describe('with chown flag (shorthand)', ()=> {
+    const expect = 'COPY --chown=42 ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.copy({ src: ['src'], dest: 'dest', chown: 42 })
+      assert.equal(result, expect)
+    })
+  })
+
+  describe('with chown flag (longhand)', ()=> {
+    const expect = 'COPY --chown=user:group ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.copy({ src: ['src'], dest: 'dest', chown: 'user:group' })
+      assert.equal(result, expect)
+    })
+  })
+
+  describe('with from flag', ()=> {
+    const expect = 'COPY --from=build ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.copy({ src: ['src'], dest: 'dest', from: 'build' })
+      assert.equal(result, expect)
+    })
+  })
+
+  describe('with both flags', ()=> {
+    const expect = 'COPY --chown=user:group --from=build ["src", "dest"]'
+    it('should produce '+expect, ()=> {
+      const result = ins.copy({ src: ['src'], dest: 'dest', from: 'build', chown: 'user:group' })
+      assert.equal(result, expect)
+    })
+  })
+
   describe('for invalid input', ()=> {
     it('should throw on either null', ()=> {
       assert.throws(() => { ins.copy({src: null, dest:null}) })

--- a/test/instruction/test_from.js
+++ b/test/instruction/test_from.js
@@ -5,13 +5,15 @@ var registry = 'registry'
 var digest = 'digest'
 var image = 'image'
 var tag = 'tag'
+var stage = 'stage'
 
-function opts(registry, image, digest, tag) {
+function opts(registry, image, digest, tag, stage) {
   var o = {}
   if(registry) o.registry = registry
   if(image) o.image = image
   if(digest) o.digest = digest
   if(tag) o.tag = tag
+  if(stage) o.stage = stage
   return o
 }
 
@@ -33,7 +35,29 @@ describe('testing instruction "FROM"', () => {
       var expected_result = expected[i]
       it('shoud make '+expected_result, ()=> {
         assert.equal(result, expected_result)
-      })    
+      })
+    }
+  })
+
+  describe('stages', () => {
+    const inputs = [
+      opts(false, image, false, false, stage),
+      opts(false, image, digest, false, stage),
+      opts(false, image, false, tag, stage),
+    ]
+
+    const expected = [
+      'FROM image AS stage',
+      'FROM image@digest AS stage',
+      'FROM image:tag AS stage'
+    ]
+
+    for (var i = 0; i < inputs.length; ++i) {
+      var result = ins.from(inputs[i])
+      var expected_result = expected[i]
+      it('should make '+expected_result, ()=> {
+        assert.equal(result, expected_result)
+      })
     }
   })
 
@@ -42,7 +66,7 @@ describe('testing instruction "FROM"', () => {
     it('should just prepend "FROM "', ()=> {
       var result = ins.from("just_prepends_from")
       assert.deepEqual(result, expected)
-    })    
+    })
   })
 
   describe('with invalid input', () => {
@@ -68,7 +92,7 @@ describe('testing instruction "FROM"', () => {
     const expected = ''
     it('', ()=> {
       assert.deepEqual(result, expected)
-    })    
+    })
   })  */
 
 })


### PR DESCRIPTION
This adds the `AS` notation for stages in the `FROM` instruction, as well as the `--from` flag for `COPY`. Since I was already working on it, I went ahead and added `--chown` to the `ADD` and `COPY` instructions. I'm about to be generating projects where I'll be copying artifacts from one stage to another, so support is needed in this library.

I also split out the multi-stage example in the README so that users can see those specific features. (It could probably use some fleshing out, though.)